### PR TITLE
fix: 이메일 헤더 인젝션 방지 및 토큰 강화 (#1)

### DIFF
--- a/src/common/delivery/gmail_sender.py
+++ b/src/common/delivery/gmail_sender.py
@@ -66,7 +66,8 @@ class GmailSender:
         try:
             message = MIMEMultipart("alternative")
             message["Subject"] = Header(subject, "utf-8")
-            message["From"] = f"{sender_name} <{self.sender_email}>"
+            safe_sender_name = sender_name.replace('\r', '').replace('\n', '').replace('\x00', '')
+            message["From"] = f"{safe_sender_name} <{self.sender_email}>"
             message["To"] = recipient
 
             html_part = MIMEText(html_content, "html", "utf-8")

--- a/src/common/subscription/email_service.py
+++ b/src/common/subscription/email_service.py
@@ -29,10 +29,12 @@ def send_verification_email(
             verification_type=verification_type
         )
 
+        safe_prefix = tenant_subject_prefix.replace('\r', '').replace('\n', '').replace('\x00', '')
+        safe_code = code.replace('\r', '').replace('\n', '').replace('\x00', '')
         if verification_type == "unsubscribe":
-            subject = f"{tenant_subject_prefix} 구독 해지 인증코드: {code}"
+            subject = f"{safe_prefix} 구독 해지 인증코드: {safe_code}"
         else:
-            subject = f"{tenant_subject_prefix} 인증코드: {code}"
+            subject = f"{safe_prefix} 인증코드: {safe_code}"
 
         sender = get_sender()
         result = sender.send(

--- a/src/common/subscription/manager.py
+++ b/src/common/subscription/manager.py
@@ -28,9 +28,8 @@ def generate_verification_code() -> str:
 
 
 def generate_unsubscribe_token(email: str) -> str:
-    """구독 해지 토큰 생성 (SHA256)"""
-    data = f"{email}{secrets.token_hex(16)}{datetime.now().isoformat()}"
-    return hashlib.sha256(data.encode()).hexdigest()[:32]
+    """구독 해지 토큰 생성 (cryptographic random)"""
+    return secrets.token_urlsafe(32)
 
 
 class SubscriptionManager:


### PR DESCRIPTION
## Summary
- `gmail_sender.py`: sender_name에서 개행/NULL 문자 제거 (이메일 헤더 인젝션 방지)
- `email_service.py`: subject 구성 시 tenant_subject_prefix, code에서 인젝션 문자 제거
- `manager.py`: unsubscribe 토큰 생성을 SHA256 truncate → `secrets.token_urlsafe(32)` 전환 (엔트로피 강화)

## Test plan
- [ ] 개행문자 포함 sender_name 입력 시 이메일 정상 발송 확인 (헤더 인젝션 미발생)
- [ ] 기존 구독/해지 플로우 정상 동작 확인
- [ ] 새 unsubscribe 토큰이 URL-safe 형식인지 확인
- [ ] `pytest` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)