### PR TITLE
feat: CSRF 보호 + N+1 쿼리 해결

### DIFF
--- a/src/common/database/repository.py
+++ b/src/common/database/repository.py
@@ -141,6 +141,24 @@ class SendHistoryRepository:
             .count() > 0
         )
 
+    @staticmethod
+    def get_sent_today_subscriber_ids(session: Session, tenant_id: str) -> set[int]:
+        """당일 발송 완료된 구독자 ID 일괄 조회 (N+1 방지)"""
+        today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        rows = (
+            session.query(SendHistory.subscriber_id)
+            .filter(
+                and_(
+                    SendHistory.tenant_id == tenant_id,
+                    SendHistory.sent_at >= today_start,
+                    SendHistory.is_success == True
+                )
+            )
+            .distinct()
+            .all()
+        )
+        return {row[0] for row in rows}
+
 
 class CollectedDataRepository:
     """수집 데이터 저장소"""

--- a/src/common/scheduler/jobs.py
+++ b/src/common/scheduler/jobs.py
@@ -99,9 +99,12 @@ def run_send_job(tenant_id: str) -> None:
             logger.warning(f"[{tenant_id}] 등록된 구독자가 없습니다.")
             return
 
+        # 당일 발송 완료된 구독자 ID 일괄 조회 (N+1 쿼리 방지)
+        sent_today_ids = SendHistoryRepository.get_sent_today_subscriber_ids(session, tenant_id)
+
         for subscriber in subscribers:
             try:
-                if SendHistoryRepository.already_sent_today(session, tenant_id, subscriber.id):
+                if subscriber.id in sent_today_ids:
                     logger.debug(f"[{tenant_id}] 이미 발송됨: {subscriber.email}")
                     continue
 


### PR DESCRIPTION
## Summary
- CSRF Origin/Referer 검증 미들웨어 추가 (외부 사이트 POST 차단)
- 테넌트 ID 형식 검증 (영숫자+언더스코어/하이픈, 64자 제한)
- N+1 쿼리 해결: subscriber별 already_sent_today 개별 조회 → 일괄 조회
  - 1000명 기준: 1001쿼리 → 2쿼리로 감소

## Test plan
- [ ] 외부 Origin POST 요청 시 403 반환 확인
- [ ] 잘못된 테넌트 ID → 400 반환 확인
- [ ] 뉴스레터 발송 시 N+1 쿼리 미발생 확인

Fixes #2, Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)