### PR TITLE
feat: 스케줄러 장애 복구 + 멱등성 + 데이터 보존 정책

### DIFF
--- a/src/common/database/models.py
+++ b/src/common/database/models.py
@@ -89,6 +89,29 @@ class CollectedData(Base):
         return f"<CollectedData(tenant={self.tenant_id}, type={self.data_type})>"
 
 
+class JobExecution(Base):
+    """스케줄러 Job 실행 이력 (멱등성 보장용)"""
+    __tablename__ = "job_executions"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    job_id = Column(String(100), nullable=False)
+    tenant_id = Column(String(50), nullable=False)
+    execution_date = Column(String(10), nullable=False)  # YYYY-MM-DD
+    status = Column(String(20), nullable=False, default="running")  # running, success, failed
+    error_message = Column(Text)
+    started_at = Column(DateTime, default=datetime.utcnow)
+    finished_at = Column(DateTime)
+
+    __table_args__ = (
+        UniqueConstraint("job_id", "tenant_id", "execution_date", name="uq_job_execution_daily"),
+        Index("idx_job_exec_status", "status"),
+        Index("idx_job_exec_date", "execution_date"),
+    )
+
+    def __repr__(self):
+        return f"<JobExecution(job={self.job_id}, tenant={self.tenant_id}, date={self.execution_date})>"
+
+
 class EmailVerification(Base):
     """이메일 인증 코드"""
     __tablename__ = "email_verifications"

--- a/src/common/scheduler/jobs.py
+++ b/src/common/scheduler/jobs.py
@@ -1,10 +1,14 @@
 """
 스케줄러 작업 정의
 테넌트별 데이터 수집 및 뉴스레터 발송
+- 지수 백오프 재시도 (최대 3회)
+- JobExecution 테이블로 멱등성 보장
+- 데이터 보존 정책 (인증 30일, 발송이력 90일)
 """
 
 import asyncio
 import logging
+import time
 from datetime import datetime
 
 from apscheduler.schedulers.blocking import BlockingScheduler
@@ -12,7 +16,8 @@ from apscheduler.triggers.cron import CronTrigger
 
 from ..database.repository import (
     get_session, CollectedDataRepository,
-    SubscriberRepository, SendHistoryRepository
+    SubscriberRepository, SendHistoryRepository,
+    JobExecutionRepository, DataRetentionRepository
 )
 from ..delivery.gmail_sender import get_sender
 from ..template.renderer import get_renderer
@@ -21,82 +26,116 @@ from ...tenant.registry import get_registry
 
 logger = logging.getLogger(__name__)
 
+MAX_RETRIES = 3
+BACKOFF_BASE = 2  # 2초, 4초, 8초
+
+
+def _retry_with_backoff(func, *args, max_retries=MAX_RETRIES):
+    """지수 백오프 재시도 래퍼. 마지막 실패 시 예외를 다시 발생시킨다."""
+    last_error = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            return func(*args)
+        except Exception as e:
+            last_error = e
+            if attempt < max_retries:
+                wait = BACKOFF_BASE ** attempt
+                logger.warning(
+                    "Retry %d/%d for %s(%s) after %ds: %s",
+                    attempt, max_retries, func.__name__, args, wait, e
+                )
+                time.sleep(wait)
+            else:
+                logger.error(
+                    "All %d retries exhausted for %s(%s): %s",
+                    max_retries, func.__name__, args, e
+                )
+    raise last_error
+
+
+def _do_collect(tenant_id: str) -> None:
+    """데이터 수집 핵심 로직 (재시도 대상)"""
+    registry = get_registry()
+    tenant = registry.get(tenant_id)
+    if not tenant:
+        raise ValueError(f"테넌트를 찾을 수 없습니다: {tenant_id}")
+
+    collected = asyncio.run(tenant.collect_data())
+
+    if not collected:
+        logger.warning("[%s] 수집된 데이터가 없습니다.", tenant_id)
+        return
+
+    with get_session() as session:
+        for data_type, data in collected.items():
+            CollectedDataRepository.upsert(session, tenant_id, data_type, data)
+
+    logger.info("[%s] 데이터 수집 완료: %s", tenant_id, list(collected.keys()))
+
 
 def run_collect_job(tenant_id: str) -> None:
-    """데이터 수집 작업"""
-    logger.info(f"[{tenant_id}] 데이터 수집 시작")
+    """데이터 수집 작업 (멱등성 + 재시도)"""
+    logger.info("[%s] 데이터 수집 시작", tenant_id)
 
-    registry = get_registry()
-    tenant = registry.get(tenant_id)
-    if not tenant:
-        logger.error(f"[{tenant_id}] 테넌트를 찾을 수 없습니다.")
-        return
+    with get_session() as session:
+        execution = JobExecutionRepository.start_execution(session, "collect", tenant_id)
+        if execution is None:
+            logger.info("[%s] 오늘 이미 수집 완료. 건너뜀.", tenant_id)
+            return
+        execution_id = execution.id
 
     try:
-        collected = asyncio.run(tenant.collect_data())
-
-        if not collected:
-            logger.warning(f"[{tenant_id}] 수집된 데이터가 없습니다.")
-            return
+        _retry_with_backoff(_do_collect, tenant_id)
 
         with get_session() as session:
-            for data_type, data in collected.items():
-                CollectedDataRepository.upsert(session, tenant_id, data_type, data)
-
-        logger.info(f"[{tenant_id}] 데이터 수집 완료: {list(collected.keys())}")
+            JobExecutionRepository.mark_success(session, execution_id)
 
     except Exception as e:
-        logger.exception(f"[{tenant_id}] 데이터 수집 중 오류: {e}")
+        with get_session() as session:
+            JobExecutionRepository.mark_failed(session, execution_id, str(e)[:500])
+        logger.exception("[%s] 데이터 수집 최종 실패: %s", tenant_id, e)
 
 
-def run_send_job(tenant_id: str) -> None:
-    """뉴스레터 발송 작업"""
-    logger.info(f"[{tenant_id}] 뉴스레터 발송 시작")
-
+def _do_send(tenant_id: str) -> None:
+    """뉴스레터 발송 핵심 로직 (재시도 대상)"""
     registry = get_registry()
     tenant = registry.get(tenant_id)
     if not tenant:
-        logger.error(f"[{tenant_id}] 테넌트를 찾을 수 없습니다.")
-        return
+        raise ValueError(f"테넌트를 찾을 수 없습니다: {tenant_id}")
 
     sender = get_sender()
     if not sender.is_configured:
-        logger.warning(f"[{tenant_id}] Gmail 설정이 완료되지 않아 발송을 건너뜁니다.")
+        logger.warning("[%s] Gmail 설정이 완료되지 않아 발송을 건너뜁니다.", tenant_id)
         return
 
     renderer = get_renderer()
     sent_count = 0
 
     with get_session() as session:
-        # 캐시된 수집 데이터 로드
         collected_data = CollectedDataRepository.get_all_latest(session, tenant_id)
 
         if not collected_data:
-            logger.warning(f"[{tenant_id}] 발송할 수집 데이터가 없습니다.")
+            logger.warning("[%s] 발송할 수집 데이터가 없습니다.", tenant_id)
             return
 
-        # 데이터 포매팅
         try:
             context = tenant.format_report(collected_data)
         except Exception as e:
-            logger.error(f"[{tenant_id}] 데이터 포매팅 실패: {e}")
+            logger.error("[%s] 데이터 포매팅 실패: %s", tenant_id, e)
             return
 
-        # HTML 렌더링
         try:
             html_content = renderer.render(tenant.email_template, context)
         except Exception as e:
-            logger.error(f"[{tenant_id}] 템플릿 렌더링 실패: {e}")
+            logger.error("[%s] 템플릿 렌더링 실패: %s", tenant_id, e)
             return
 
-        # 이메일 제목
         subject = tenant.generate_subject()
 
-        # 구독자 조회 및 발송
         subscribers = SubscriberRepository.get_all_active(session, tenant_id)
 
         if not subscribers:
-            logger.warning(f"[{tenant_id}] 등록된 구독자가 없습니다.")
+            logger.warning("[%s] 등록된 구독자가 없습니다.", tenant_id)
             return
 
         # 당일 발송 완료된 구독자 ID 일괄 조회 (N+1 쿼리 방지)
@@ -105,10 +144,9 @@ def run_send_job(tenant_id: str) -> None:
         for subscriber in subscribers:
             try:
                 if subscriber.id in sent_today_ids:
-                    logger.debug(f"[{tenant_id}] 이미 발송됨: {subscriber.email}")
+                    logger.debug("[%s] 이미 발송됨: %s", tenant_id, subscriber.email)
                     continue
 
-                # 구독자별 해지 URL 치환
                 unsubscribe_url = (
                     f"{settings.web_base_url}/{tenant_id}"
                     f"/unsubscribe/token/{subscriber.unsubscribe_token}"
@@ -129,14 +167,37 @@ def run_send_job(tenant_id: str) -> None:
 
                 if result.success:
                     sent_count += 1
-                    logger.info(f"[{tenant_id}] 발송 성공: {subscriber.email}")
+                    logger.info("[%s] 발송 성공: %s", tenant_id, subscriber.email)
                 else:
-                    logger.error(f"[{tenant_id}] 발송 실패: {subscriber.email} - {result.error_message}")
+                    logger.error("[%s] 발송 실패: %s - %s", tenant_id, subscriber.email, result.error_message)
 
             except Exception as e:
-                logger.error(f"[{tenant_id}] 발송 중 오류 ({subscriber.email}): {e}")
+                logger.error("[%s] 발송 중 오류 (%s): %s", tenant_id, subscriber.email, e)
 
-    logger.info(f"[{tenant_id}] 뉴스레터 발송 완료: {sent_count}건")
+    logger.info("[%s] 뉴스레터 발송 완료: %d건", tenant_id, sent_count)
+
+
+def run_send_job(tenant_id: str) -> None:
+    """뉴스레터 발송 작업 (멱등성 + 재시도)"""
+    logger.info("[%s] 뉴스레터 발송 시작", tenant_id)
+
+    with get_session() as session:
+        execution = JobExecutionRepository.start_execution(session, "send", tenant_id)
+        if execution is None:
+            logger.info("[%s] 오늘 이미 발송 완료. 건너뜀.", tenant_id)
+            return
+        execution_id = execution.id
+
+    try:
+        _retry_with_backoff(_do_send, tenant_id)
+
+        with get_session() as session:
+            JobExecutionRepository.mark_success(session, execution_id)
+
+    except Exception as e:
+        with get_session() as session:
+            JobExecutionRepository.mark_failed(session, execution_id, str(e)[:500])
+        logger.exception("[%s] 뉴스레터 발송 최종 실패: %s", tenant_id, e)
 
 
 def send_welcome_newsletter(tenant_id: str, email: str) -> bool:
@@ -145,17 +206,17 @@ def send_welcome_newsletter(tenant_id: str, email: str) -> bool:
     수집된 데이터가 없으면 건너뛴다.
     발송 성공 시 send_history에 기록하여 당일 중복 발송을 방지한다.
     """
-    logger.info(f"[{tenant_id}] 웰컴 뉴스레터 발송: {email}")
+    logger.info("[%s] 웰컴 뉴스레터 발송: %s", tenant_id, email)
 
     registry = get_registry()
     tenant = registry.get(tenant_id)
     if not tenant:
-        logger.error(f"[{tenant_id}] 테넌트를 찾을 수 없습니다.")
+        logger.error("[%s] 테넌트를 찾을 수 없습니다.", tenant_id)
         return False
 
     sender = get_sender()
     if not sender.is_configured:
-        logger.warning(f"[{tenant_id}] Gmail 설정이 완료되지 않아 웰컴 발송을 건너뜁니다.")
+        logger.warning("[%s] Gmail 설정이 완료되지 않아 웰컴 발송을 건너뜁니다.", tenant_id)
         return False
 
     renderer = get_renderer()
@@ -164,16 +225,16 @@ def send_welcome_newsletter(tenant_id: str, email: str) -> bool:
         with get_session() as session:
             subscriber = SubscriberRepository.get_active_by_email(session, tenant_id, email)
             if not subscriber:
-                logger.warning(f"[{tenant_id}] 구독자를 찾을 수 없습니다: {email}")
+                logger.warning("[%s] 구독자를 찾을 수 없습니다: %s", tenant_id, email)
                 return False
 
             if SendHistoryRepository.already_sent_today(session, tenant_id, subscriber.id):
-                logger.info(f"[{tenant_id}] 이미 오늘 발송됨, 웰컴 건너뜀: {email}")
+                logger.info("[%s] 이미 오늘 발송됨, 웰컴 건너뜀: %s", tenant_id, email)
                 return True
 
             collected_data = CollectedDataRepository.get_all_latest(session, tenant_id)
             if not collected_data:
-                logger.info(f"[{tenant_id}] 수집 데이터 없음, 웰컴 발송 건너뜀: {email}")
+                logger.info("[%s] 수집 데이터 없음, 웰컴 발송 건너뜀: %s", tenant_id, email)
                 return False
 
             context = tenant.format_report(collected_data)
@@ -200,15 +261,31 @@ def send_welcome_newsletter(tenant_id: str, email: str) -> bool:
             )
 
             if result.success:
-                logger.info(f"[{tenant_id}] 웰컴 뉴스레터 발송 성공: {email}")
+                logger.info("[%s] 웰컴 뉴스레터 발송 성공: %s", tenant_id, email)
             else:
-                logger.error(f"[{tenant_id}] 웰컴 뉴스레터 발송 실패: {email} - {result.error_message}")
+                logger.error("[%s] 웰컴 뉴스레터 발송 실패: %s - %s", tenant_id, email, result.error_message)
 
             return result.success
 
     except Exception as e:
-        logger.exception(f"[{tenant_id}] 웰컴 뉴스레터 발송 중 오류: {e}")
+        logger.exception("[%s] 웰컴 뉴스레터 발송 중 오류: %s", tenant_id, e)
         return False
+
+
+def run_data_retention_job() -> None:
+    """데이터 보존 정책 실행 (매일 새벽 실행)"""
+    logger.info("데이터 보존 정책 실행 시작")
+    try:
+        with get_session() as session:
+            v_count = DataRetentionRepository.cleanup_expired_verifications(session, retention_days=30)
+            h_count = DataRetentionRepository.cleanup_old_send_history(session, retention_days=90)
+            j_count = DataRetentionRepository.cleanup_old_job_executions(session, retention_days=30)
+        logger.info(
+            "데이터 보존 정책 완료: 인증=%d건, 발송이력=%d건, Job이력=%d건 삭제",
+            v_count, h_count, j_count
+        )
+    except Exception as e:
+        logger.exception("데이터 보존 정책 실행 중 오류: %s", e)
 
 
 def register_all_jobs(scheduler: BlockingScheduler) -> None:
@@ -242,7 +319,16 @@ def register_all_jobs(scheduler: BlockingScheduler) -> None:
         )
 
         logger.info(
-            f"[{tid}] 스케줄 등록: "
-            f"수집 {config['collect_hour']:02d}:{config['collect_minute']:02d}, "
-            f"발송 {config['send_hour']:02d}:{config['send_minute']:02d}"
+            "[%s] 스케줄 등록: 수집 %02d:%02d, 발송 %02d:%02d",
+            tid, config["collect_hour"], config["collect_minute"],
+            config["send_hour"], config["send_minute"]
         )
+
+    # 데이터 보존 정책 Job (매일 03:00 실행)
+    scheduler.add_job(
+        run_data_retention_job,
+        trigger=CronTrigger(hour=3, minute=0),
+        id="data_retention",
+        name="Data Retention Cleanup",
+    )
+    logger.info("데이터 보존 정책 Job 등록: 매일 03:00")

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -440,6 +440,28 @@ async def unsubscribe_by_token(request: Request, tenant_id: str, token: str):
         db.close()
 
 
+# ==================== Health Check ====================
+
+@app.get("/health")
+async def health_check():
+    """서비스 상태 확인"""
+    from sqlalchemy import text
+
+    status = {"status": "ok", "service": "NewsLetterPlatform"}
+    try:
+        SessionLocal = get_session_factory()
+        db = SessionLocal()
+        try:
+            db.execute(text("SELECT 1"))
+            status["database"] = "ok"
+        finally:
+            db.close()
+    except Exception:
+        status["database"] = "error"
+        status["status"] = "degraded"
+    return status
+
+
 # ==================== 서버 실행 ====================
 
 def run_server():


### PR DESCRIPTION
## Summary
- Job 실패 시 지수 백오프 재시도 (최대 3회, 2/4/8초 간격)
- JobExecution 테이블로 일별 멱등성 보장 (당일 성공 시 재실행 건너뜀)
- 데이터 보존 정책: 인증 30일, 발송이력 90일, Job이력 30일 자동 정리
- `/health` 엔드포인트 추가 (DB 연결 상태 포함)

fixes #4

## Changes
- `models.py`: JobExecution 모델 추가 (job_id, tenant_id, execution_date UNIQUE)
- `repository.py`: JobExecutionRepository + DataRetentionRepository 추가
- `jobs.py`: _retry_with_backoff 래퍼, 멱등성 가드, run_data_retention_job 추가
- `app.py`: /health 엔드포인트 추가

## Test plan
- [ ] 스케줄러 Job 실패 시 재시도가 3회까지 백오프로 동작하는지 확인
- [ ] 동일 Job이 당일 두 번 실행되면 두 번째가 건너뛰어지는지 확인
- [ ] 보존 기간 초과 데이터가 정리되는지 확인
- [ ] /health 엔드포인트가 DB 상태를 반환하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)