### PR TITLE
feat(web): 공개 /api/health 엔드포인트 추가

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -8,12 +8,12 @@ import threading
 from urllib.parse import urlparse
 
 from fastapi import FastAPI, Request, Form, HTTPException
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from ..config import settings
-from ..common.database.repository import get_session_factory
+from ..common.database.repository import get_session_factory, SendHistoryRepository
 from ..common.subscription.manager import SubscriptionManager
 from ..common.subscription.email_service import send_verification_email
 from ..common.scheduler.jobs import send_welcome_newsletter
@@ -81,6 +81,50 @@ def resolve_template(tenant_id: str, template_name: str) -> str:
     if override_path.exists():
         return f"overrides/{tenant_id}/{template_name}"
     return template_name
+
+
+# ==================== 공개 헬스체크 ====================
+
+@app.get("/api/health")
+async def api_health():
+    """공개 헬스체크 (인증 불요, 항상 200, 당일 발송 통계 포함)
+
+    QA Agent가 파싱하여 자체 판정:
+    - HTTP 연결 실패 → FAIL (서비스 다운)
+    - 200 + total=0 → WARN (당일 미발송)
+    - 200 + failed>0 → WARN (일부 발송 실패)
+    - 200 + failed=0, total>0 → PASS (정상)
+    """
+    try:
+        registry = get_registry()
+        tenants = registry.get_all()
+        SessionLocal = get_session_factory()
+        db = SessionLocal()
+        try:
+            tenants_stats = {}
+            total_all = 0
+            failed_all = 0
+            for tenant in tenants:
+                stats = SendHistoryRepository.get_today_stats(db, tenant.tenant_id)
+                tenants_stats[tenant.tenant_id] = stats
+                total_all += stats["total"]
+                failed_all += stats["failed"]
+
+            return JSONResponse({
+                "status": "ok",
+                "total": total_all,
+                "success": total_all - failed_all,
+                "failed": failed_all,
+                "tenants": tenants_stats,
+            })
+        finally:
+            db.close()
+    except Exception as e:
+        logger.error(f"Health check 오류: {e}")
+        return JSONResponse(
+            {"status": "error", "message": str(e)},
+            status_code=503,
+        )
 
 
 # ==================== 랜딩 페이지 ====================


### PR DESCRIPTION
## Summary
- 인증 불요 공개 헬스체크 엔드포인트 `/api/health` 신설
- 항상 200 반환 (서버 실제 장애 시에만 503), 테넌트별 당일 발송 통계 JSON 포함
- QA Agent의 `send-status` 전략과 연동하여 발송 검증 자동화

## 변경 사항
- `src/web/app.py`: `GET /api/health` 엔드포인트 추가 (admin 라우터 이전 등록)
- 기존 `/admin/api/health` (인증 필요, HTML 응답)와 별개의 공개 JSON API

## 응답 형식
```json
{
  "status": "ok",
  "total": 42, "success": 40, "failed": 2,
  "tenants": { "tenant_id": { "total": 20, "success": 19, "failed": 1 } }
}
```

## QA Agent 판정 기준
| 조건 | 판정 |
|------|------|
| HTTP 연결 실패 | FAIL (서비스 다운) |
| 200 + total=0 | WARN (당일 미발송) |
| 200 + failed > 0 | WARN (일부 발송 실패) |
| 200 + failed=0, total > 0 | PASS (정상) |

## Test plan
- [ ] `curl http://localhost:4050/api/health` → 200 + JSON 응답 확인
- [ ] 발송 전/후 total, success, failed 값 변화 확인
- [ ] 인증 없이 접근 가능한지 확인 (기존 admin 엔드포인트와 구분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)