### PR TITLE
fix(httpx): OrbStack NO_PROXY IPv6 CIDR 파싱 오류 회피

### DIFF
--- a/src/common/database/__init__.py
+++ b/src/common/database/__init__.py
@@ -3,21 +3,25 @@
 from .models import (
     Base, Subscriber, SendHistory, CollectedData,
     CollectedDataHistory, EmailVerification,
-    VerificationType, NewsletterType, NewsletterArchive, SentArticle
+    VerificationType, NewsletterType, NewsletterArchive, SentArticle,
+    BounceLog, CollectionMetric,
 )
 from .repository import (
     init_db, get_session, get_session_factory,
     SubscriberRepository, SendHistoryRepository,
     CollectedDataRepository, EmailVerificationRepository,
-    NewsletterArchiveRepository, SentArticleRepository
+    NewsletterArchiveRepository, SentArticleRepository,
+    BounceLogRepository, CollectionMetricRepository,
 )
 
 __all__ = [
     "Base", "Subscriber", "SendHistory", "CollectedData",
     "CollectedDataHistory", "EmailVerification",
     "VerificationType", "NewsletterType", "NewsletterArchive", "SentArticle",
+    "BounceLog", "CollectionMetric",
     "init_db", "get_session", "get_session_factory",
     "SubscriberRepository", "SendHistoryRepository",
     "CollectedDataRepository", "EmailVerificationRepository",
     "NewsletterArchiveRepository", "SentArticleRepository",
+    "BounceLogRepository", "CollectionMetricRepository",
 ]

--- a/src/common/database/models.py
+++ b/src/common/database/models.py
@@ -210,6 +210,48 @@ class EmailVerification(Base):
         return f"<EmailVerification(tenant={self.tenant_id}, email='{self.email}')>"
 
 
+class CollectionMetric(Base):
+    """수집 단계 메트릭 (테넌트 × 데이터 타입 × 엔드포인트)
+
+    `run_collect_job` 1회당 collector 가 호출한 각 API 엔드포인트 단위로 1행.
+    회귀 감지/V1 digest 실효성 측정/staleness 알림의 공통 입력 테이블.
+    """
+    __tablename__ = "collection_metrics"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    tenant_id = Column(String(50), nullable=False)
+    # 'daily' | 'weekly' | 'monthly' — run_collect_job 의 newsletter_type
+    newsletter_type = Column(String(20), default="daily", nullable=False)
+    # 수집 단위 (예: 'headlines', 'company_digest', 'papers', 'github_releases')
+    data_type = Column(String(50), nullable=False)
+    api_path = Column(String(200))                  # 실제 호출 경로 (POST alias 면 alias 경로)
+    raw_count = Column(Integer, default=0, nullable=False)
+    final_count = Column(Integer, default=0, nullable=False)
+    excluded_by_ids = Column(Integer, default=0, nullable=False)
+    excluded_by_companies = Column(Integer, default=0, nullable=False)
+    effective_days = Column(Integer)                # 실제 사용된 lookback 윈도 (nullable)
+    fallback_used = Column(Boolean, default=False, nullable=False)  # 풀 확장/POST alias 발동
+    latency_ms = Column(Integer, default=0, nullable=False)
+    error = Column(String(500))                     # 실패 시 메시지 (nullable)
+    collected_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("idx_collection_metrics_tenant_time",
+              "tenant_id", "collected_at"),
+        Index("idx_collection_metrics_type_time",
+              "tenant_id", "data_type", "collected_at"),
+        Index("idx_collection_metrics_fallback",
+              "tenant_id", "fallback_used", "collected_at"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<CollectionMetric(tenant={self.tenant_id}, type={self.data_type}, "
+            f"raw={self.raw_count}, final={self.final_count}, "
+            f"fallback={self.fallback_used})>"
+        )
+
+
 class BounceLog(Base):
     """이메일 bounce 이력 (NDR 자동 처리)
 

--- a/src/common/database/repository.py
+++ b/src/common/database/repository.py
@@ -34,7 +34,8 @@ def _today_start_utc() -> datetime:
 from .models import (
     Base, Subscriber, SendHistory, CollectedData,
     CollectedDataHistory, EmailVerification, VerificationType,
-    NewsletterType, NewsletterArchive, SentArticle, BounceLog
+    NewsletterType, NewsletterArchive, SentArticle, BounceLog,
+    CollectionMetric,
 )
 
 
@@ -63,6 +64,7 @@ def init_db(database_url: str = "sqlite:///./data/newsletterplatform.db") -> Non
     _migrate_send_history_send_mode(_engine)
     _migrate_subscriber_send_slot(_engine)
     _migrate_sent_articles_company_name(_engine)
+    _migrate_collection_metrics(_engine)
 
 
 def _migrate_subscriber_send_slot(engine) -> None:
@@ -107,6 +109,31 @@ def _migrate_sent_articles_company_name(engine) -> None:
                 logger.info("sent_articles 테이블에 company_name 컬럼 + 인덱스 추가 완료")
     except Exception as e:
         logger.debug(f"sent_articles company_name 마이그레이션 스킵: {e}")
+
+
+def _migrate_collection_metrics(engine) -> None:
+    """collection_metrics 테이블/인덱스 idempotent 생성.
+
+    Base.metadata.create_all 이 누락된 인덱스를 만들지 못하는 경우를 대비해
+    명시적으로 생성 보장한다.
+    """
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(
+                "CREATE INDEX IF NOT EXISTS idx_collection_metrics_tenant_time "
+                "ON collection_metrics (tenant_id, collected_at)"
+            ))
+            conn.execute(text(
+                "CREATE INDEX IF NOT EXISTS idx_collection_metrics_type_time "
+                "ON collection_metrics (tenant_id, data_type, collected_at)"
+            ))
+            conn.execute(text(
+                "CREATE INDEX IF NOT EXISTS idx_collection_metrics_fallback "
+                "ON collection_metrics (tenant_id, fallback_used, collected_at)"
+            ))
+            conn.commit()
+    except Exception as e:
+        logger.debug(f"collection_metrics 인덱스 보장 스킵: {e}")
 
 
 def _migrate_send_history_newsletter_type(engine) -> None:
@@ -1030,6 +1057,161 @@ class SentArticleRepository:
         deleted = (
             session.query(SentArticle)
             .filter(SentArticle.sent_at < cutoff)
+            .delete(synchronize_session=False)
+        )
+        return int(deleted or 0)
+
+
+class CollectionMetricRepository:
+    """수집 메트릭 저장소
+
+    collector 가 누적해 둔 _metrics 딕셔너리 리스트를 한 번에 적재한다.
+    소비처:
+      - 운영 가시화 (admin dashboard)
+      - 회귀 감지 (P2 diff 배너)
+      - 트랙 E V1 digest 노출 메트릭 집계
+    """
+
+    _ALLOWED_KEYS = {
+        "data_type", "api_path",
+        "raw_count", "final_count",
+        "excluded_by_ids", "excluded_by_companies",
+        "effective_days", "fallback_used", "latency_ms", "error",
+    }
+
+    @staticmethod
+    def record_many(
+        session: Session,
+        tenant_id: str,
+        newsletter_type: str,
+        metrics: list[dict],
+    ) -> int:
+        """수집 메트릭 다건 적재. 실제 INSERT 된 건수 반환.
+
+        - `metrics` 각 항목은 collector 의 `_track()` 컨텍스트 매니저가 채운 dict
+        - 필수 키: `data_type`. 나머지는 default 적용.
+        - 빈 리스트면 0 반환 (no-op).
+        """
+        if not metrics:
+            return 0
+        rows: list[CollectionMetric] = []
+        now = datetime.utcnow()
+        for m in metrics:
+            data_type = m.get("data_type")
+            if not data_type:
+                continue
+            row = CollectionMetric(
+                tenant_id=tenant_id,
+                newsletter_type=newsletter_type or "daily",
+                data_type=str(data_type)[:50],
+                api_path=(m.get("api_path") or None),
+                raw_count=int(m.get("raw_count") or 0),
+                final_count=int(m.get("final_count") or 0),
+                excluded_by_ids=int(m.get("excluded_by_ids") or 0),
+                excluded_by_companies=int(m.get("excluded_by_companies") or 0),
+                effective_days=(
+                    int(m["effective_days"])
+                    if m.get("effective_days") is not None else None
+                ),
+                fallback_used=bool(m.get("fallback_used") or False),
+                latency_ms=int(m.get("latency_ms") or 0),
+                error=((m.get("error") or None) and str(m.get("error"))[:500]),
+                collected_at=now,
+            )
+            rows.append(row)
+        if not rows:
+            return 0
+        session.add_all(rows)
+        session.flush()
+        return len(rows)
+
+    @staticmethod
+    def get_recent(
+        session: Session,
+        tenant_id: Optional[str] = None,
+        days: int = 7,
+        limit: int = 500,
+    ) -> list[CollectionMetric]:
+        """최근 N일 수집 메트릭 (admin 패널 raw 뷰)."""
+        since = _today_start_utc() - timedelta(days=days)
+        query = session.query(CollectionMetric).filter(
+            CollectionMetric.collected_at >= since
+        )
+        if tenant_id:
+            query = query.filter(CollectionMetric.tenant_id == tenant_id)
+        return (
+            query
+            .order_by(CollectionMetric.collected_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    @staticmethod
+    def get_daily_summary(
+        session: Session,
+        tenant_id: str,
+        days: int = 7,
+    ) -> list[dict]:
+        """일자 × data_type 별 합계/평균.
+
+        Returns: [{date, data_type, n, sum_raw, sum_final,
+                   avg_latency_ms, fallback_n, error_n}, ...]
+        """
+        since = _today_start_utc() - timedelta(days=days)
+        rows = (
+            session.query(
+                func.date(CollectionMetric.collected_at).label("date"),
+                CollectionMetric.data_type,
+                func.count(CollectionMetric.id).label("n"),
+                func.sum(CollectionMetric.raw_count).label("sum_raw"),
+                func.sum(CollectionMetric.final_count).label("sum_final"),
+                func.avg(CollectionMetric.latency_ms).label("avg_latency_ms"),
+                func.sum(
+                    func.cast(CollectionMetric.fallback_used, Integer)
+                ).label("fallback_n"),
+                func.sum(
+                    func.cast(
+                        CollectionMetric.error.isnot(None), Integer
+                    )
+                ).label("error_n"),
+            )
+            .filter(
+                and_(
+                    CollectionMetric.tenant_id == tenant_id,
+                    CollectionMetric.collected_at >= since,
+                )
+            )
+            .group_by(
+                func.date(CollectionMetric.collected_at),
+                CollectionMetric.data_type,
+            )
+            .order_by(
+                func.date(CollectionMetric.collected_at).desc(),
+                CollectionMetric.data_type.asc(),
+            )
+            .all()
+        )
+        return [
+            {
+                "date": str(r.date),
+                "data_type": r.data_type,
+                "n": int(r.n or 0),
+                "sum_raw": int(r.sum_raw or 0),
+                "sum_final": int(r.sum_final or 0),
+                "avg_latency_ms": int(r.avg_latency_ms or 0),
+                "fallback_n": int(r.fallback_n or 0),
+                "error_n": int(r.error_n or 0),
+            }
+            for r in rows
+        ]
+
+    @staticmethod
+    def purge_older_than(session: Session, days: int = 90) -> int:
+        """보존 기간 초과 메트릭 삭제. sent_articles 와 동일 정책."""
+        cutoff = _today_start_utc() - timedelta(days=days)
+        deleted = (
+            session.query(CollectionMetric)
+            .filter(CollectionMetric.collected_at < cutoff)
             .delete(synchronize_session=False)
         )
         return int(deleted or 0)

--- a/src/common/scheduler/jobs.py
+++ b/src/common/scheduler/jobs.py
@@ -15,7 +15,8 @@ from apscheduler.triggers.cron import CronTrigger
 from ..database.repository import (
     get_session, CollectedDataRepository,
     SubscriberRepository, SendHistoryRepository,
-    NewsletterArchiveRepository, SentArticleRepository
+    NewsletterArchiveRepository, SentArticleRepository,
+    CollectionMetricRepository,
 )
 from ..delivery.gmail_sender import get_sender
 from ..delivery.bounce_processor import run_bounce_processor
@@ -190,6 +191,24 @@ def run_collect_job(tenant_id: str, newsletter_type: str = "daily") -> None:
         logger.exception(
             f"[{tenant_id}]{type_label} 데이터 수집 중 오류: {e}. "
             "이전 캐시 데이터로 발송됩니다."
+        )
+
+    # 수집 메트릭 영속화 — 성공/실패 무관(부분 수집도 가시화).
+    # collector 가 누적해 둔 _metrics 를 1회 drain 후 DB 기록한다.
+    try:
+        collection_metrics = tenant.extract_collection_metrics()
+        if collection_metrics:
+            with get_session() as session:
+                CollectionMetricRepository.record_many(
+                    session, tenant_id, newsletter_type, collection_metrics
+                )
+            logger.info(
+                f"[{tenant_id}]{type_label} collection_metrics 기록: "
+                f"{len(collection_metrics)}건"
+            )
+    except Exception as e:
+        logger.warning(
+            f"[{tenant_id}]{type_label} collection_metrics 기록 실패: {e}"
         )
 
     update_health("collect")

--- a/src/common/security/abuse_guard.py
+++ b/src/common/security/abuse_guard.py
@@ -89,7 +89,7 @@ async def verify_turnstile(token: str, secret: str, remote_ip: Optional[str] = N
         payload["remoteip"] = remote_ip
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=5.0, trust_env=False) as client:
             resp = await client.post(
                 "https://challenges.cloudflare.com/turnstile/v0/siteverify",
                 data=payload,

--- a/src/tenant/allergy_insight/__init__.py
+++ b/src/tenant/allergy_insight/__init__.py
@@ -118,6 +118,9 @@ class AllergyInsightTenant(BaseTenant):
             exclude_companies=exclude_companies,
         )
 
+    def extract_collection_metrics(self) -> List[Dict[str, Any]]:
+        return self._collector.drain_metrics()
+
     def format_report(self, collected_data: Dict[str, Any]) -> Dict[str, Any]:
         return self._formatter.format(collected_data)
 

--- a/src/tenant/allergy_insight/collector.py
+++ b/src/tenant/allergy_insight/collector.py
@@ -35,6 +35,9 @@ from ...config import settings
 logger = logging.getLogger(__name__)
 
 API_TIMEOUT = 60.0
+# trust_env=False: OrbStack 런타임이 컨테이너에 자동 주입하는 NO_PROXY 의 IPv6 CIDR
+# 항목(fd07:.../64 형식)이 httpx URLPattern 파서를 깨뜨림 (InvalidURL: Invalid port).
+# 내부 호출에 외부 proxy 가 필요 없으므로 환경 변수 자체를 신뢰하지 않는다.
 
 
 class AllergyInsightCollector:
@@ -99,7 +102,7 @@ class AllergyInsightCollector:
         }
 
         async def _request():
-            async with httpx.AsyncClient(timeout=API_TIMEOUT) as client:
+            async with httpx.AsyncClient(timeout=API_TIMEOUT, trust_env=False) as client:
                 response = await client.post(url, json=payload)
                 response.raise_for_status()
                 data = response.json()
@@ -123,7 +126,7 @@ class AllergyInsightCollector:
             headers["Authorization"] = f"Bearer {self._token}"
 
         async def _request():
-            async with httpx.AsyncClient(timeout=API_TIMEOUT) as client:
+            async with httpx.AsyncClient(timeout=API_TIMEOUT, trust_env=False) as client:
                 response = await client.get(url, headers=headers, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -143,7 +146,7 @@ class AllergyInsightCollector:
             headers["Authorization"] = f"Bearer {self._token}"
 
         async def _request():
-            async with httpx.AsyncClient(timeout=API_TIMEOUT) as client:
+            async with httpx.AsyncClient(timeout=API_TIMEOUT, trust_env=False) as client:
                 response = await client.post(url, headers=headers, json=json_body)
                 response.raise_for_status()
                 return response.json()

--- a/src/tenant/allergy_insight/collector.py
+++ b/src/tenant/allergy_insight/collector.py
@@ -22,6 +22,8 @@ N2 신규 인용 endpoints (전문가용 섹션):
 """
 
 import logging
+import time
+from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
@@ -43,6 +45,49 @@ class AllergyInsightCollector:
             api_base_url or settings.allergy_insight_api_url
         ).rstrip("/")
         self._token: Optional[str] = None
+        # 수집 메트릭 누적. drain_metrics() 호출 시 비워진다.
+        self._metrics: list[dict] = []
+
+    def drain_metrics(self) -> list[dict]:
+        """누적된 _metrics 를 반환하고 내부 버퍼를 비운다."""
+        m, self._metrics = self._metrics, []
+        return m
+
+    @contextmanager
+    def _track(
+        self,
+        *,
+        data_type: str,
+        api_path: str,
+        excluded_by_ids: int = 0,
+        excluded_by_companies: int = 0,
+    ):
+        """수집 메트릭 추적 컨텍스트 매니저.
+
+        각 `_collect_*` 메서드가 `with self._track(...) as m:` 로 감싼다.
+        본문에서 `m["raw_count"]` 등을 직접 갱신한다. 예외가 발생해도 finally 에서
+        latency 와 함께 _metrics 에 append 한다 (부분 실패도 가시화).
+        """
+        started = time.monotonic()
+        metric: dict = {
+            "data_type": data_type,
+            "api_path": api_path,
+            "raw_count": 0,
+            "final_count": 0,
+            "excluded_by_ids": int(excluded_by_ids or 0),
+            "excluded_by_companies": int(excluded_by_companies or 0),
+            "effective_days": None,
+            "fallback_used": False,
+            "error": None,
+        }
+        try:
+            yield metric
+        except Exception as e:
+            metric["error"] = str(e)[:480]
+            raise
+        finally:
+            metric["latency_ms"] = int((time.monotonic() - started) * 1000)
+            self._metrics.append(metric)
 
     async def _login(self) -> str:
         """관리자 로그인으로 JWT 토큰 획득"""
@@ -115,20 +160,48 @@ class AllergyInsightCollector:
 
     async def _collect_news(self, page_size: int = 100) -> list[dict]:
         """뉴스 전체 목록 수집 (주간/월간용) - GET /api/admin/news"""
-        data = await self._get(f"/api/admin/news?page=1&page_size={page_size}")
-        return data.get("items", [])
+        with self._track(data_type="news", api_path="/api/admin/news") as m:
+            try:
+                data = await self._get(
+                    f"/api/admin/news?page=1&page_size={page_size}"
+                )
+                items = data.get("items", []) or []
+                m["raw_count"] = len(items)
+                m["final_count"] = len(items)
+                return items
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                raise
 
     async def _collect_news_stats(self) -> dict:
         """뉴스 통계 수집 - GET /api/admin/news/stats"""
-        return await self._get("/api/admin/news/stats")
+        with self._track(
+            data_type="news_stats", api_path="/api/admin/news/stats"
+        ) as m:
+            try:
+                data = await self._get("/api/admin/news/stats")
+                m["raw_count"] = 1
+                m["final_count"] = 1
+                return data
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                raise
 
     async def _collect_papers(self, page_size: int = 100) -> list[dict]:
         """논문 목록 수집 - GET /api/papers (공개 API)"""
-        data = await self._get(
-            f"/api/papers?page=1&page_size={page_size}",
-            auth_required=False,
-        )
-        return data.get("items", [])
+        with self._track(data_type="papers", api_path="/api/papers") as m:
+            try:
+                data = await self._get(
+                    f"/api/papers?page=1&page_size={page_size}",
+                    auth_required=False,
+                )
+                items = data.get("items", []) or []
+                m["raw_count"] = len(items)
+                m["final_count"] = len(items)
+                return items
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                raise
 
     # ─────────────────────────────────────────────────────────────
     # Redesign Phase 1 endpoints (fail-safe: 실패 시 빈 구조 반환)
@@ -154,47 +227,66 @@ class AllergyInsightCollector:
         """
         exclude_ids = [int(i) for i in (exclude_ids or [])]
         exclude_csv = ",".join(str(i) for i in exclude_ids)
-        try:
-            if exclude_csv and len(exclude_csv) > self._GET_EXCLUDE_IDS_BUDGET:
-                logger.info(
-                    f"AllergyInsight 헤드라인: exclude_ids={len(exclude_ids)}건 → POST alias 사용"
-                )
-                raw = await self._post(
-                    "/api/public/analytics/headlines/today:select",
-                    auth_required=False,
-                    json_body={
+        with self._track(
+            data_type="headlines",
+            api_path="/api/public/analytics/headlines/today",
+            excluded_by_ids=len(exclude_ids),
+        ) as m:
+            try:
+                if exclude_csv and len(exclude_csv) > self._GET_EXCLUDE_IDS_BUDGET:
+                    logger.info(
+                        f"AllergyInsight 헤드라인: exclude_ids={len(exclude_ids)}건 → POST alias 사용"
+                    )
+                    m["api_path"] = "/api/public/analytics/headlines/today:select"
+                    m["fallback_used"] = True
+                    raw = await self._post(
+                        "/api/public/analytics/headlines/today:select",
+                        auth_required=False,
+                        json_body={
+                            "limit": limit,
+                            "one_per_company": True,
+                            "fallback_days": [1, 2],
+                            "exclude_ids": exclude_ids,
+                        },
+                    )
+                else:
+                    params: Dict[str, Any] = {
                         "limit": limit,
-                        "one_per_company": True,
-                        "fallback_days": [1, 2],
-                        "exclude_ids": exclude_ids,
-                    },
+                        "one_per_company": "true",
+                        "fallback_days": "1,2",
+                    }
+                    if exclude_csv:
+                        params["exclude_ids"] = exclude_csv
+                    raw = await self._get(
+                        "/api/public/analytics/headlines/today",
+                        auth_required=False,
+                        params=params,
+                    )
+                body = self._unwrap(raw)
+                headlines = body.get("headlines", []) or []
+                excluded_ids = body.get("excluded_ids", []) or []
+                # 백엔드가 meta.effective_days 를 노출하면 사용, 없으면 None.
+                meta = body.get("meta") or {}
+                eff = meta.get("effective_days") if isinstance(meta, dict) else None
+                if eff is not None:
+                    m["effective_days"] = int(eff)
+                    if int(eff) > 1:
+                        # lookback 자동 확장도 fallback 신호로 표시
+                        m["fallback_used"] = True
+                # raw_count: 백엔드가 본 풀 크기 추정 (반환 + 백엔드 제외분)
+                m["raw_count"] = len(headlines) + len(excluded_ids)
+                m["final_count"] = len(headlines)
+                logger.info(
+                    f"AllergyInsight 헤드라인 수집 완료: {len(headlines)}건 "
+                    f"(exclude {len(exclude_ids)})"
                 )
-            else:
-                params: Dict[str, Any] = {
-                    "limit": limit,
-                    "one_per_company": "true",
-                    "fallback_days": "1,2",
-                }
-                if exclude_csv:
-                    params["exclude_ids"] = exclude_csv
-                raw = await self._get(
-                    "/api/public/analytics/headlines/today",
-                    auth_required=False,
-                    params=params,
+                return {"headlines": headlines, "excluded_ids": excluded_ids}
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                logger.warning(
+                    f"AllergyInsight 헤드라인 수집 실패 (빈 구조 폴백): {e}"
                 )
-            body = self._unwrap(raw)
-            headlines = body.get("headlines", []) or []
-            excluded_ids = body.get("excluded_ids", []) or []
-            logger.info(
-                f"AllergyInsight 헤드라인 수집 완료: {len(headlines)}건 "
-                f"(exclude {len(exclude_ids)})"
-            )
-            return {"headlines": headlines, "excluded_ids": excluded_ids}
-        except Exception as e:
-            logger.warning(
-                f"AllergyInsight 헤드라인 수집 실패 (빈 구조 폴백): {e}"
-            )
-            return {"headlines": [], "excluded_ids": []}
+                return {"headlines": [], "excluded_ids": []}
 
     async def _collect_company_digest(
         self,
@@ -272,35 +364,54 @@ class AllergyInsightCollector:
                     break
             return kept
 
-        try:
-            companies_7d = await _fetch(7)
-            filtered = _apply_filters(companies_7d)
-            if len(filtered) < target_count:
-                # 풀이 부족하면 14일로 확장 후 한 번 더 시도
-                companies_14d = await _fetch(14)
-                seen_names = {c.get("company_name") for c in filtered}
-                extra_pool = [
-                    c for c in companies_14d
-                    if c.get("company_name") not in seen_names
-                ]
-                extra_filtered = _apply_filters(
-                    extra_pool, max_per_category=3
+        with self._track(
+            data_type="company_digest",
+            api_path="/api/public/analytics/company-digest",
+            excluded_by_ids=len(exclude_ids or []),
+            excluded_by_companies=len(excluded_companies),
+        ) as m:
+            try:
+                companies_7d = await _fetch(7)
+                filtered = _apply_filters(companies_7d)
+                m["effective_days"] = 7
+                if len(filtered) < target_count:
+                    # 풀이 부족하면 14일로 확장 후 한 번 더 시도
+                    m["fallback_used"] = True
+                    m["effective_days"] = 14
+                    companies_14d = await _fetch(14)
+                    seen_names = {c.get("company_name") for c in filtered}
+                    extra_pool = [
+                        c for c in companies_14d
+                        if c.get("company_name") not in seen_names
+                    ]
+                    extra_filtered = _apply_filters(
+                        extra_pool, max_per_category=3
+                    )
+                    filtered.extend(
+                        extra_filtered[: target_count - len(filtered)]
+                    )
+                # raw_count 는 7일 풀 크기, fallback 발동 시 14일 풀로 갱신
+                m["raw_count"] = (
+                    len(companies_7d)
+                    if not m["fallback_used"]
+                    else len(companies_7d) + max(
+                        0, len(filtered) - len(companies_7d)
+                    )
                 )
-                filtered.extend(
-                    extra_filtered[: target_count - len(filtered)]
+                m["final_count"] = len(filtered)
+                logger.info(
+                    f"AllergyInsight 기업 다이제스트 수집 완료: "
+                    f"raw={len(companies_7d)} → filtered={len(filtered)} "
+                    f"(exclude_ids={len(exclude_ids or [])}, "
+                    f"exclude_companies={len(excluded_companies)})"
                 )
-            logger.info(
-                f"AllergyInsight 기업 다이제스트 수집 완료: "
-                f"raw={len(companies_7d)} → filtered={len(filtered)} "
-                f"(exclude_ids={len(exclude_ids or [])}, "
-                f"exclude_companies={len(excluded_companies)})"
-            )
-            return filtered
-        except Exception as e:
-            logger.warning(
-                f"AllergyInsight 기업 다이제스트 수집 실패 (빈 리스트 폴백): {e}"
-            )
-            return []
+                return filtered
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                logger.warning(
+                    f"AllergyInsight 기업 다이제스트 수집 실패 (빈 리스트 폴백): {e}"
+                )
+                return []
 
     async def _collect_drug_updates(self, days: int = 7) -> Dict[str, Any]:
         """약물·처방제 업데이트 수집 (openFDA + MFDS).
@@ -317,34 +428,42 @@ class AllergyInsightCollector:
             "recalls": [],
             "total": 0,
         }
-        try:
-            raw = await self._get(
-                "/api/public/drugs/updates",
-                auth_required=False,
-                params={"days": days, "type": "all"},
-            )
-            body = self._unwrap(raw)
-            result = {
-                "new_approvals": body.get("new_approvals", []) or [],
-                "label_changes": body.get("label_changes", []) or [],
-                "blackbox_warnings": body.get("blackbox_warnings", []) or [],
-                "recalls": body.get("recalls", []) or [],
-            }
-            result["total"] = (
-                len(result["new_approvals"])
-                + len(result["label_changes"])
-                + len(result["blackbox_warnings"])
-                + len(result["recalls"])
-            )
-            logger.info(
-                f"AllergyInsight 약물 업데이트 수집 완료: total={result['total']}"
-            )
-            return result
-        except Exception as e:
-            logger.warning(
-                f"AllergyInsight 약물 업데이트 수집 실패 (빈 구조 폴백): {e}"
-            )
-            return empty
+        with self._track(
+            data_type="drug_updates",
+            api_path="/api/public/drugs/updates",
+        ) as m:
+            m["effective_days"] = days
+            try:
+                raw = await self._get(
+                    "/api/public/drugs/updates",
+                    auth_required=False,
+                    params={"days": days, "type": "all"},
+                )
+                body = self._unwrap(raw)
+                result = {
+                    "new_approvals": body.get("new_approvals", []) or [],
+                    "label_changes": body.get("label_changes", []) or [],
+                    "blackbox_warnings": body.get("blackbox_warnings", []) or [],
+                    "recalls": body.get("recalls", []) or [],
+                }
+                result["total"] = (
+                    len(result["new_approvals"])
+                    + len(result["label_changes"])
+                    + len(result["blackbox_warnings"])
+                    + len(result["recalls"])
+                )
+                m["raw_count"] = result["total"]
+                m["final_count"] = result["total"]
+                logger.info(
+                    f"AllergyInsight 약물 업데이트 수집 완료: total={result['total']}"
+                )
+                return result
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                logger.warning(
+                    f"AllergyInsight 약물 업데이트 수집 실패 (빈 구조 폴백): {e}"
+                )
+                return empty
 
     # ─────────────────────────────────────────────────────────────
     # N2: 전문가용 신규 섹션 — 알러지 인사이트 스폿라이트 / 신흥 치료법 /
@@ -414,57 +533,67 @@ class AllergyInsightCollector:
         self,
         direction: str = "rising",
         limit: int = 5,
+        track_label: Optional[str] = None,
     ) -> list[dict]:
         """알러젠 상승/하락 랭킹 수집.
 
         direction: rising / declining / stable / new (백엔드 패턴 준수).
+        track_label: 메트릭 data_type 오버라이드. spotlight 처럼 동일 엔드포인트를
+            다른 의미로 호출할 때 중복 라벨 방지용. None 이면 'allergen_trend_<direction>'.
         실패 또는 빈 응답 → 빈 리스트.
 
         Returns: [{allergen_code, label_kr, paper_count, total_papers,
                    mention_rate, change_rate, top_link_types: [...]}]
         """
-        try:
-            raw = await self._get(
-                "/api/public/analytics/allergen-trend/ranking",
-                auth_required=False,
-                params={"direction": direction, "limit": limit},
-            )
-            body = self._unwrap(raw)
-            allergens = body.get("allergens", []) or []
-            result = []
-            for a in allergens:
-                code = a.get("allergen_code") or ""
-                top_link_types = a.get("top_link_types") or []
-                # 한글 라벨 부착
-                lt_display = [
-                    {
-                        "type": lt.get("type"),
-                        "label": self._LINK_TYPE_KR.get(
-                            (lt.get("type") or "").lower(), lt.get("type")
-                        ),
-                        "count": lt.get("count", 0),
-                    }
-                    for lt in top_link_types[:3]
-                ]
-                result.append({
-                    "allergen_code": code,
-                    "label_kr": self._allergen_label(code),
-                    "paper_count": a.get("paper_count", 0),
-                    "total_papers": a.get("total_papers", 0),
-                    "mention_rate": a.get("mention_rate", 0.0),
-                    "change_rate": a.get("change_rate", 0.0),
-                    "top_link_types": lt_display,
-                })
-            logger.info(
-                f"AllergyInsight 알러젠 랭킹 수집 완료 ({direction}): {len(result)}건"
-            )
-            return result
-        except Exception as e:
-            logger.warning(
-                f"AllergyInsight 알러젠 랭킹({direction}) 수집 실패 "
-                f"(빈 리스트 폴백): {e}"
-            )
-            return []
+        with self._track(
+            data_type=(track_label or f"allergen_trend_{direction}"),
+            api_path="/api/public/analytics/allergen-trend/ranking",
+        ) as m:
+            try:
+                raw = await self._get(
+                    "/api/public/analytics/allergen-trend/ranking",
+                    auth_required=False,
+                    params={"direction": direction, "limit": limit},
+                )
+                body = self._unwrap(raw)
+                allergens = body.get("allergens", []) or []
+                result = []
+                for a in allergens:
+                    code = a.get("allergen_code") or ""
+                    top_link_types = a.get("top_link_types") or []
+                    # 한글 라벨 부착
+                    lt_display = [
+                        {
+                            "type": lt.get("type"),
+                            "label": self._LINK_TYPE_KR.get(
+                                (lt.get("type") or "").lower(), lt.get("type")
+                            ),
+                            "count": lt.get("count", 0),
+                        }
+                        for lt in top_link_types[:3]
+                    ]
+                    result.append({
+                        "allergen_code": code,
+                        "label_kr": self._allergen_label(code),
+                        "paper_count": a.get("paper_count", 0),
+                        "total_papers": a.get("total_papers", 0),
+                        "mention_rate": a.get("mention_rate", 0.0),
+                        "change_rate": a.get("change_rate", 0.0),
+                        "top_link_types": lt_display,
+                    })
+                m["raw_count"] = len(allergens)
+                m["final_count"] = len(result)
+                logger.info(
+                    f"AllergyInsight 알러젠 랭킹 수집 완료 ({direction}): {len(result)}건"
+                )
+                return result
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                logger.warning(
+                    f"AllergyInsight 알러젠 랭킹({direction}) 수집 실패 "
+                    f"(빈 리스트 폴백): {e}"
+                )
+                return []
 
     async def _collect_treatments_overview(self) -> Dict[str, Any]:
         """신흥 치료법 통계 수집.
@@ -480,45 +609,54 @@ class AllergyInsightCollector:
             "by_type": {},
             "top_emerging": [],
         }
-        try:
-            raw = await self._get(
-                "/api/public/analytics/treatments/overview",
-                auth_required=False,
-            )
-            body = self._unwrap(raw)
-            top_treatments = body.get("top_treatments", []) or []
-            rising = body.get("rising_treatments", []) or []
-            # rising 우선, 없으면 top_treatments 중 trend_direction == "new" 만
-            emerging_pool = rising or [
-                t for t in top_treatments
-                if (t.get("trend_direction") or "").lower() in ("new", "rising")
-            ]
-            top_emerging = [
-                {
-                    "name": t.get("treatment_name") or "",
-                    "type": (t.get("treatment_type") or "").lower(),
-                    "paper_count": t.get("paper_count", 0),
-                    "direction": t.get("trend_direction") or "new",
+        with self._track(
+            data_type="treatments",
+            api_path="/api/public/analytics/treatments/overview",
+        ) as m:
+            try:
+                raw = await self._get(
+                    "/api/public/analytics/treatments/overview",
+                    auth_required=False,
+                )
+                body = self._unwrap(raw)
+                top_treatments = body.get("top_treatments", []) or []
+                rising = body.get("rising_treatments", []) or []
+                # rising 우선, 없으면 top_treatments 중 trend_direction == "new" 만
+                emerging_pool = rising or [
+                    t for t in top_treatments
+                    if (t.get("trend_direction") or "").lower() in ("new", "rising")
+                ]
+                top_emerging = [
+                    {
+                        "name": t.get("treatment_name") or "",
+                        "type": (t.get("treatment_type") or "").lower(),
+                        "paper_count": t.get("paper_count", 0),
+                        "direction": t.get("trend_direction") or "new",
+                    }
+                    for t in emerging_pool[:6]
+                    if t.get("treatment_name")
+                ]
+                result = {
+                    "latest_year": body.get("latest_year"),
+                    "total_treatments": body.get("total_treatments", 0),
+                    "by_type": body.get("by_type", {}) or {},
+                    "top_emerging": top_emerging,
                 }
-                for t in emerging_pool[:6]
-                if t.get("treatment_name")
-            ]
-            result = {
-                "latest_year": body.get("latest_year"),
-                "total_treatments": body.get("total_treatments", 0),
-                "by_type": body.get("by_type", {}) or {},
-                "top_emerging": top_emerging,
-            }
-            logger.info(
-                f"AllergyInsight 신흥 치료법 수집 완료: "
-                f"top_emerging={len(top_emerging)}건"
-            )
-            return result
-        except Exception as e:
-            logger.warning(
-                f"AllergyInsight 신흥 치료법 수집 실패 (빈 구조 폴백): {e}"
-            )
-            return empty
+                m["raw_count"] = (
+                    len(top_treatments) + len(rising)
+                )
+                m["final_count"] = len(top_emerging)
+                logger.info(
+                    f"AllergyInsight 신흥 치료법 수집 완료: "
+                    f"top_emerging={len(top_emerging)}건"
+                )
+                return result
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                logger.warning(
+                    f"AllergyInsight 신흥 치료법 수집 실패 (빈 구조 폴백): {e}"
+                )
+                return empty
 
     async def _collect_spotlight(
         self, rotation_seed: int = 0, candidate_limit: int = 8
@@ -529,7 +667,9 @@ class AllergyInsightCollector:
         Returns: 단일 dict 또는 None (데이터 없음).
         """
         candidates = await self._collect_allergen_ranking(
-            direction="rising", limit=candidate_limit
+            direction="rising",
+            limit=candidate_limit,
+            track_label="spotlight",
         )
         if not candidates:
             return None
@@ -552,23 +692,32 @@ class AllergyInsightCollector:
              "top_companies": [...], "drug_updates_summary": {...}}
             실패 시 빈 dict. 템플릿이 falsy 체크로 섹션 숨김.
         """
-        try:
-            params: Dict[str, Any] = {"window_days": window_days}
-            if report_date:
-                params["report_date"] = report_date
-            raw = await self._get(
-                "/api/public/analytics/weekly-metrics",
-                auth_required=False,
-                params=params,
-            )
-            body = self._unwrap(raw)
-            logger.info("AllergyInsight 주간 메트릭 수집 완료")
-            return body or {}
-        except Exception as e:
-            logger.warning(
-                f"AllergyInsight 주간 메트릭 수집 실패 (빈 dict 폴백): {e}"
-            )
-            return {}
+        with self._track(
+            data_type="weekly_metrics",
+            api_path="/api/public/analytics/weekly-metrics",
+        ) as m:
+            m["effective_days"] = window_days
+            try:
+                params: Dict[str, Any] = {"window_days": window_days}
+                if report_date:
+                    params["report_date"] = report_date
+                raw = await self._get(
+                    "/api/public/analytics/weekly-metrics",
+                    auth_required=False,
+                    params=params,
+                )
+                body = self._unwrap(raw)
+                if body:
+                    m["raw_count"] = 1
+                    m["final_count"] = 1
+                logger.info("AllergyInsight 주간 메트릭 수집 완료")
+                return body or {}
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                logger.warning(
+                    f"AllergyInsight 주간 메트릭 수집 실패 (빈 dict 폴백): {e}"
+                )
+                return {}
 
     def _transform_news(self, raw_items: list[dict]) -> list[dict]:
         """v2.0.0 뉴스 아이템 → daily_report top_news 포맷 변환"""

--- a/src/tenant/base.py
+++ b/src/tenant/base.py
@@ -103,6 +103,28 @@ class BaseTenant(ABC):
         """
         return True
 
+    def extract_collection_metrics(self) -> List[Dict[str, Any]]:
+        """직전 `collect_data` / `collect_summary_data` 호출에서 누적된 수집 메트릭.
+
+        반환되는 dict 리스트는 `CollectionMetricRepository.record_many` 가 그대로
+        소비한다. 기본 구현은 빈 리스트 — collector 가 메트릭을 누적하는 테넌트만
+        오버라이드한다.
+
+        각 dict 의 키 (모두 optional, `data_type` 만 필수):
+          - `data_type` (str, 필수): 'headlines' / 'company_digest' / 'github_releases' …
+          - `api_path` (str): 실제 호출 경로
+          - `raw_count` / `final_count` (int)
+          - `excluded_by_ids` / `excluded_by_companies` (int)
+          - `effective_days` (int|None)
+          - `fallback_used` (bool)
+          - `latency_ms` (int)
+          - `error` (str|None)
+
+        구현은 collector 의 `drain_metrics()` 를 그대로 반환하는 게 일반적.
+        스케줄러는 매 `run_collect_job` 마다 1회 호출하므로 호출 즉시 비워야 한다.
+        """
+        return []
+
     def extract_sent_article_entries(
         self, context: Dict[str, Any]
     ) -> List[tuple]:

--- a/src/tenant/standup/__init__.py
+++ b/src/tenant/standup/__init__.py
@@ -91,6 +91,9 @@ class StandUpTenant(BaseTenant):
             return {}
         return await self._collector.collect_weekly(date_from, date_to)
 
+    def extract_collection_metrics(self) -> List[Dict[str, Any]]:
+        return self._collector.drain_metrics()
+
     def format_summary_report(self, newsletter_type: str,
                               history_data: list,
                               collected_data: Dict[str, Any] = None) -> Dict[str, Any]:

--- a/src/tenant/standup/collector.py
+++ b/src/tenant/standup/collector.py
@@ -6,6 +6,8 @@
 """
 
 import logging
+import time
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone, date as date_t
 from typing import Any, Dict, List, Optional
 
@@ -26,6 +28,34 @@ class StandUpCollector:
         self.api_base_url = (
             api_base_url or settings.standup_api_url
         ).rstrip("/")
+        self._metrics: list[dict] = []
+
+    def drain_metrics(self) -> list[dict]:
+        m, self._metrics = self._metrics, []
+        return m
+
+    @contextmanager
+    def _track(self, *, data_type: str, api_path: str):
+        started = time.monotonic()
+        metric: dict = {
+            "data_type": data_type,
+            "api_path": api_path,
+            "raw_count": 0,
+            "final_count": 0,
+            "excluded_by_ids": 0,
+            "excluded_by_companies": 0,
+            "effective_days": None,
+            "fallback_used": False,
+            "error": None,
+        }
+        try:
+            yield metric
+        except Exception as e:
+            metric["error"] = str(e)[:480]
+            raise
+        finally:
+            metric["latency_ms"] = int((time.monotonic() - started) * 1000)
+            self._metrics.append(metric)
 
     async def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         url = f"{self.api_base_url}{path}"
@@ -39,14 +69,22 @@ class StandUpCollector:
         return await retry_async(_request)
 
     async def _list_newsletters(self, limit: int = 5) -> List[Dict[str, Any]]:
-        try:
-            data = await self._get(
-                "/api/v1/insight/newsletters", params={"limit": limit}
-            )
-            return data if isinstance(data, list) else []
-        except Exception as e:
-            logger.warning(f"StandUp /insight/newsletters 실패: {e}")
-            return []
+        with self._track(
+            data_type="newsletters",
+            api_path="/api/v1/insight/newsletters",
+        ) as m:
+            try:
+                data = await self._get(
+                    "/api/v1/insight/newsletters", params={"limit": limit}
+                )
+                items = data if isinstance(data, list) else []
+                m["raw_count"] = len(items)
+                m["final_count"] = len(items)
+                return items
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                logger.warning(f"StandUp /insight/newsletters 실패: {e}")
+                return []
 
     async def _list_events(
         self,
@@ -54,15 +92,24 @@ class StandUpCollector:
         limit: int = 200,
         source_type: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        try:
-            params: Dict[str, Any] = {"days": days, "limit": limit}
-            if source_type:
-                params["source_type"] = source_type
-            data = await self._get("/api/v1/insight/events", params=params)
-            return data if isinstance(data, list) else []
-        except Exception as e:
-            logger.warning(f"StandUp /insight/events 실패: {e}")
-            return []
+        with self._track(
+            data_type="events",
+            api_path="/api/v1/insight/events",
+        ) as m:
+            m["effective_days"] = days
+            try:
+                params: Dict[str, Any] = {"days": days, "limit": limit}
+                if source_type:
+                    params["source_type"] = source_type
+                data = await self._get("/api/v1/insight/events", params=params)
+                items = data if isinstance(data, list) else []
+                m["raw_count"] = len(items)
+                m["final_count"] = len(items)
+                return items
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                logger.warning(f"StandUp /insight/events 실패: {e}")
+                return []
 
     @staticmethod
     def _parse_dt(value: Optional[str]) -> Optional[str]:

--- a/src/tenant/standup/collector.py
+++ b/src/tenant/standup/collector.py
@@ -61,7 +61,7 @@ class StandUpCollector:
         url = f"{self.api_base_url}{path}"
 
         async def _request():
-            async with httpx.AsyncClient(timeout=API_TIMEOUT) as client:
+            async with httpx.AsyncClient(timeout=API_TIMEOUT, trust_env=False) as client:
                 response = await client.get(url, params=params)
                 response.raise_for_status()
                 return response.json()

--- a/src/tenant/tech_briefing/__init__.py
+++ b/src/tenant/tech_briefing/__init__.py
@@ -76,6 +76,9 @@ class TechBriefingTenant(BaseTenant):
             exclude_companies=exclude_companies,
         )
 
+    def extract_collection_metrics(self) -> List[Dict[str, Any]]:
+        return self._collector.drain_metrics()
+
     def format_report(self, collected_data: Dict[str, Any]) -> Dict[str, Any]:
         return self._formatter.format(collected_data)
 

--- a/src/tenant/tech_briefing/collector.py
+++ b/src/tenant/tech_briefing/collector.py
@@ -417,7 +417,7 @@ class TechBriefingCollector:
             }
             전부 실패시 빈 dict.
         """
-        async with httpx.AsyncClient(timeout=API_TIMEOUT) as client:
+        async with httpx.AsyncClient(timeout=API_TIMEOUT, trust_env=False) as client:
             github_task = self._fetch_github_releases(client)
             cve_task = self._fetch_cves(client)
             rss_task = self._fetch_rss(client)

--- a/src/tenant/tech_briefing/collector.py
+++ b/src/tenant/tech_briefing/collector.py
@@ -7,6 +7,8 @@ LLM 호출은 MVP 범위 외 (raw description / RSS summary 그대로 사용, tr
 import asyncio
 import logging
 import re
+import time
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -62,6 +64,34 @@ class TechBriefingCollector:
 
     def __init__(self):
         self._gh_token = settings.tech_github_token or ""
+        self._metrics: list[dict] = []
+
+    def drain_metrics(self) -> list[dict]:
+        m, self._metrics = self._metrics, []
+        return m
+
+    @contextmanager
+    def _track(self, *, data_type: str, api_path: str):
+        started = time.monotonic()
+        metric: dict = {
+            "data_type": data_type,
+            "api_path": api_path,
+            "raw_count": 0,
+            "final_count": 0,
+            "excluded_by_ids": 0,
+            "excluded_by_companies": 0,
+            "effective_days": None,
+            "fallback_used": False,
+            "error": None,
+        }
+        try:
+            yield metric
+        except Exception as e:
+            metric["error"] = str(e)[:480]
+            raise
+        finally:
+            metric["latency_ms"] = int((time.monotonic() - started) * 1000)
+            self._metrics.append(metric)
 
     # ─── GitHub Releases ──────────────────────────────────────────
 
@@ -138,15 +168,29 @@ class TechBriefingCollector:
             async with semaphore:
                 return await _one(*args)
 
-        results = await asyncio.gather(
-            *[_bounded(args) for args in GITHUB_REPOS],
-            return_exceptions=False,
-        )
-        flat: List[Dict[str, Any]] = []
-        for r in results:
-            flat.extend(r)
-        logger.info(f"GitHub releases 수집: {len(flat)}건")
-        return flat
+        with self._track(
+            data_type="github_releases",
+            api_path="https://api.github.com/repos/{owner}/{repo}/releases",
+        ) as m:
+            try:
+                results = await asyncio.gather(
+                    *[_bounded(args) for args in GITHUB_REPOS],
+                    return_exceptions=False,
+                )
+                flat: List[Dict[str, Any]] = []
+                for r in results:
+                    flat.extend(r)
+                # raw_count: repo 호출 수, final_count: 정규화된 release 수
+                m["raw_count"] = len(GITHUB_REPOS)
+                m["final_count"] = len(flat)
+                # 토큰 없는 경우 동시성 제약(2) 으로 풀 확장 fallback 신호
+                if not self._gh_token:
+                    m["fallback_used"] = True
+                logger.info(f"GitHub releases 수집: {len(flat)}건")
+                return flat
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                raise
 
     # ─── NVD CVE feed ─────────────────────────────────────────────
 
@@ -167,78 +211,93 @@ class TechBriefingCollector:
 
         seen_ids: set[str] = set()
         all_cves: List[Dict[str, Any]] = []
+        cve_errors = 0
 
-        for kw in NVD_KEYWORDS:
-            params = {
-                "keywordSearch": kw,
-                "pubStartDate": _fmt(start_dt),
-                "pubEndDate": _fmt(end_dt),
-                "resultsPerPage": 20,
-            }
-            try:
-                async def _request():
-                    response = await client.get(url, params=params, timeout=API_TIMEOUT)
-                    if response.status_code == 403:
-                        raise RuntimeError("NVD 403 — rate limit 초과 의심")
-                    response.raise_for_status()
-                    return response.json()
+        with self._track(
+            data_type="cves",
+            api_path="https://services.nvd.nist.gov/rest/json/cves/2.0",
+        ) as m:
+            m["effective_days"] = NVD_LOOKBACK_DAYS
+            for kw in NVD_KEYWORDS:
+                params = {
+                    "keywordSearch": kw,
+                    "pubStartDate": _fmt(start_dt),
+                    "pubEndDate": _fmt(end_dt),
+                    "resultsPerPage": 20,
+                }
+                try:
+                    async def _request():
+                        response = await client.get(url, params=params, timeout=API_TIMEOUT)
+                        if response.status_code == 403:
+                            raise RuntimeError("NVD 403 — rate limit 초과 의심")
+                        response.raise_for_status()
+                        return response.json()
 
-                payload = await retry_async(_request, max_retries=2, base_delay=2.0)
-            except Exception as e:
-                logger.warning(f"NVD CVE 실패 [{kw}]: {e}")
-                continue
-
-            for vuln in payload.get("vulnerabilities", []) or []:
-                cve = vuln.get("cve") or {}
-                cve_id = cve.get("id") or ""
-                if not cve_id or cve_id in seen_ids:
+                    payload = await retry_async(_request, max_retries=2, base_delay=2.0)
+                except Exception as e:
+                    cve_errors += 1
+                    logger.warning(f"NVD CVE 실패 [{kw}]: {e}")
                     continue
-                seen_ids.add(cve_id)
 
-                descs = cve.get("descriptions") or []
-                en_desc = next(
-                    (d.get("value") for d in descs if d.get("lang") == "en"),
-                    "",
-                )
+                for vuln in payload.get("vulnerabilities", []) or []:
+                    cve = vuln.get("cve") or {}
+                    cve_id = cve.get("id") or ""
+                    if not cve_id or cve_id in seen_ids:
+                        continue
+                    seen_ids.add(cve_id)
 
-                # CVSS v3.1 우선, 없으면 v3.0, 없으면 v2.
-                metrics = cve.get("metrics") or {}
-                cvss = None
-                severity = None
-                for key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
-                    arr = metrics.get(key) or []
-                    if arr:
-                        item0 = arr[0]
-                        cvss_data = item0.get("cvssData") or {}
-                        cvss = cvss_data.get("baseScore")
-                        severity = (
-                            cvss_data.get("baseSeverity")
-                            or item0.get("baseSeverity")
-                            or ""
-                        ).lower() or None
-                        break
+                    descs = cve.get("descriptions") or []
+                    en_desc = next(
+                        (d.get("value") for d in descs if d.get("lang") == "en"),
+                        "",
+                    )
 
-                published = _parse_iso(cve.get("published"))
+                    # CVSS v3.1 우선, 없으면 v3.0, 없으면 v2.
+                    metrics = cve.get("metrics") or {}
+                    cvss = None
+                    severity = None
+                    for key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+                        arr = metrics.get(key) or []
+                        if arr:
+                            item0 = arr[0]
+                            cvss_data = item0.get("cvssData") or {}
+                            cvss = cvss_data.get("baseScore")
+                            severity = (
+                                cvss_data.get("baseSeverity")
+                                or item0.get("baseSeverity")
+                                or ""
+                            ).lower() or None
+                            break
 
-                all_cves.append({
-                    "source": "nvd_cve",
-                    "project": kw,
-                    "project_short": kw,
-                    "ecosystem": _ecosystem_for_keyword(kw),
-                    "tier": "S",  # CVE 는 자동으로 S 가중 (보안 신호 가장 큼)
-                    "title": f"{cve_id} ({kw})",
-                    "cve_id": cve_id,
-                    "url": f"https://nvd.nist.gov/vuln/detail/{cve_id}",
-                    "published_at": published,
-                    "summary": _strip_html(en_desc, max_len=320),
-                    "cvss": cvss,
-                    "severity": severity,
-                    "matched_keyword": kw,
-                    "dedup_key": f"cve:{cve_id}",
-                })
-            # rate limit 보호 — keyword 간 짧은 간격.
-            await asyncio.sleep(0.7 if self._gh_token else 1.2)
+                    published = _parse_iso(cve.get("published"))
 
+                    all_cves.append({
+                        "source": "nvd_cve",
+                        "project": kw,
+                        "project_short": kw,
+                        "ecosystem": _ecosystem_for_keyword(kw),
+                        "tier": "S",  # CVE 는 자동으로 S 가중 (보안 신호 가장 큼)
+                        "title": f"{cve_id} ({kw})",
+                        "cve_id": cve_id,
+                        "url": f"https://nvd.nist.gov/vuln/detail/{cve_id}",
+                        "published_at": published,
+                        "summary": _strip_html(en_desc, max_len=320),
+                        "cvss": cvss,
+                        "severity": severity,
+                        "matched_keyword": kw,
+                        "dedup_key": f"cve:{cve_id}",
+                    })
+                # rate limit 보호 — keyword 간 짧은 간격.
+                await asyncio.sleep(0.7 if self._gh_token else 1.2)
+
+            m["raw_count"] = len(NVD_KEYWORDS)
+            m["final_count"] = len(all_cves)
+            if cve_errors:
+                # 일부 키워드 실패는 부분 fallback 으로 표시 (전부 실패 아니면 error 비움)
+                if cve_errors >= len(NVD_KEYWORDS):
+                    m["error"] = f"all keywords failed (n={cve_errors})"
+                else:
+                    m["fallback_used"] = True
         logger.info(f"NVD CVE 수집: {len(all_cves)}건 (unique)")
         return all_cves
 
@@ -314,16 +373,28 @@ class TechBriefingCollector:
                 })
             return entries
 
-        results = await asyncio.gather(
-            *[_one(label, url, eco, tier)
-              for label, url, eco, tier in RSS_FEEDS],
-            return_exceptions=False,
-        )
-        flat: List[Dict[str, Any]] = []
-        for r in results:
-            flat.extend(r)
-        logger.info(f"RSS 수집: {len(flat)}건")
-        return flat
+        with self._track(
+            data_type="rss",
+            api_path="(rss feeds)",
+        ) as m:
+            try:
+                results = await asyncio.gather(
+                    *[_one(label, url, eco, tier)
+                      for label, url, eco, tier in RSS_FEEDS],
+                    return_exceptions=False,
+                )
+                flat: List[Dict[str, Any]] = []
+                for r in results:
+                    flat.extend(r)
+                # _one 은 실패도 [] 로 폴백하므로 fetch 실패와 본문 없음을 구분할 수 없다.
+                # raw_count = feed 수, final_count = 모은 엔트리 수만 적재 (충분히 운영용).
+                m["raw_count"] = len(RSS_FEEDS)
+                m["final_count"] = len(flat)
+                logger.info(f"RSS 수집: {len(flat)}건")
+                return flat
+            except Exception as e:
+                m["error"] = str(e)[:480]
+                raise
 
     # ─── 통합 수집 ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- OrbStack 런타임이 컨테이너에 자동 주입하는 `NO_PROXY` 의 IPv6 CIDR(`fd07:b51a:cc66:f0::/64`)이 `httpx.URLPattern` 파서를 깨뜨려 `AsyncClient` 생성 단계에서 `InvalidURL: Invalid port: 'b51a:cc66:f0::'` 발생.
- 5/12·5/13 AllergyInsight 일일 수집이 전량 실패 → 캐시 폴백 → 3일 연속 동일 콘텐츠 발송 사고. `NEWSLETTER_FRESHNESS_IMPROVEMENT_PLAN` **AC-1 위반**.
- 모든 `httpx.AsyncClient(...)` 호출에 `trust_env=False` 추가 (4파일 / 6곳).
- 함께 적용한 운영 작업: `.env` 의 `ALLERGY_INSIGHT_API_URL` 을 `deploy-prod.yml` workflow 와 일치하도록 `http://host.docker.internal:9040` 으로 복구.

## Root cause chain

1. NewsLetterPlatform 컨테이너 재시작 (5/11 KST 19:38)
2. OrbStack 이 `HTTPS_PROXY`/`NO_PROXY` 자동 주입 — `NO_PROXY` 안에 IPv6 CIDR 포함
3. `httpx.AsyncClient.__init__` 의 `URLPattern` 생성 단계에서 IPv6 CIDR 을 URL 로 파싱 시도 → `b51a:cc66:f0::` 를 port 부분으로 잘못 해석 → `InvalidURL`
4. 모든 outbound HTTP 호출 실패 → graceful fallback (빈 구조) → 캐시 발송
5. 5/11 수집 캐시(`daily_report`) 가 5/12·5/13 발송에 그대로 재사용 → 3일 연속 동일 콘텐츠

## Test plan

- [x] 운영 컨테이너에서 패치 적용 후 `trust_env=False` 단독 검증 (`host.docker.internal:9040` 호출 200 OK)
- [x] 수동 collect 트리거(`run_collect_job('allergy-insight')`) 13개 API 호출 모두 200 OK
- [x] `dedup: 최근 7일 13건 / 기업 7건` 정상 전달 — P3 작동 확인
- [x] `collection_metrics 기록: 8건` — C1 작동 확인
- [x] `daily_report` 수집 완료 (헤드라인 1건 신규, 논문 20건, 트렌드 1/5)
- [ ] 5/14 정상 스케줄 발송 모니터링 — `sent_articles` 에 신규 article_id 기록 확인

## Related docs

- `Claude-Opus-bluevlad/services/newsletterplatform/allergy-insight/NEWSLETTER_REDESIGN_SPEC.md` §2.1, §3.2.1
- `Claude-Opus-bluevlad/services/newsletterplatform/allergy-insight/NEWSLETTER_FRESHNESS_IMPROVEMENT_PLAN.md` AC-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)